### PR TITLE
:rocket: Add collection versioning and deprecation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,13 @@
 Changes
 =======
 
+Version 1.0.2
+-------------
+
+- Review way to represent deprecated collections and versioning (`#88 <https://github.com/brazil-data-cube/bdc-stac/issues/88>`_)
+- Add fixture for tests
+- Upgrade Docker base image for python:3.11
+
 
 Version 1.0.1 (2022-12-06)
 --------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/gpl-3.0.html>.
 #
 ARG GIT_COMMIT
-ARG BASE_IMAGE=python:3.8-slim-buster
+ARG BASE_IMAGE=python:3.11
 FROM ${BASE_IMAGE}
 
 # Image metadata
@@ -27,12 +27,8 @@ LABEL "org.repo.git_commit"="${GIT_COMMIT}"
 LABEL "org.repo.licenses"="GPLv3"
 
 # Build arguments
-ARG BDC_STAC_VERSION="1.0.1"
+ARG BDC_STAC_VERSION="1.0.2"
 ARG BDC_STAC_INSTALL_PATH="/opt/bdc-stac/${BDC_STAC_VERSION}"
-
-RUN apt-get update -y \
-    && apt-get install -y libpq-dev git \
-    && rm -rf /var/lib/apt/lists/*
 
 COPY . ${BDC_STAC_INSTALL_PATH}
 WORKDIR ${BDC_STAC_INSTALL_PATH}

--- a/bdc_stac/version.py
+++ b/bdc_stac/version.py
@@ -22,4 +22,4 @@ and parsed by ``setup.py``.
 """
 
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/bdc_stac/views.py
+++ b/bdc_stac/views.py
@@ -19,11 +19,11 @@
 
 
 import gzip
+from urllib.parse import urlencode
 
 from bdc_auth_client.decorators import oauth2
 from flask import abort, current_app, request
 from werkzeug.exceptions import HTTPException, InternalServerError
-from werkzeug.urls import url_encode
 
 from . import config
 from .controller import (
@@ -49,10 +49,10 @@ def before_request():
     request.assets_kwargs = ""
 
     if config.BDC_STAC_ASSETS_ARGS:
-        assets_kwargs = {arg: request.args.get(arg) for arg in config.BDC_STAC_ASSETS_ARGS.split(",")}
+        assets_kwargs = {arg: request.args.get(arg) for arg in config.BDC_STAC_ASSETS_ARGS.split(",") if request.args.get(arg) is not None}
         if "access_token" in request.args:
             assets_kwargs["access_token"] = request.args.get("access_token")
-        assets_kwargs = "?" + url_encode(assets_kwargs) if url_encode(assets_kwargs) else ""
+        assets_kwargs = "?" + urlencode(assets_kwargs) if urlencode(assets_kwargs) else ""
         request.assets_kwargs = assets_kwargs
 
 
@@ -240,7 +240,7 @@ def collection_items(collection_id, roles=None, **kwargs):
         args["page"] = items.next_num
         item_collection["links"].append(
             {
-                "href": f"{resolve_stac_url()}/collections/{collection_id}/items{f'?{url_encode(args)}' if len(args) > 0 else ''}",
+                "href": f"{resolve_stac_url()}/collections/{collection_id}/items{f'?{urlencode(args)}' if len(args) > 0 else ''}",
                 "rel": "next",
             }
         )
@@ -248,7 +248,7 @@ def collection_items(collection_id, roles=None, **kwargs):
         args["page"] = items.prev_num
         item_collection["links"].append(
             {
-                "href": f"{resolve_stac_url()}/collections/{collection_id}/items{f'?{url_encode(args)}' if len(args) > 0 else ''}",
+                "href": f"{resolve_stac_url()}/collections/{collection_id}/items{f'?{urlencode(args)}' if len(args) > 0 else ''}",
                 "rel": "prev",
             }
         )
@@ -352,7 +352,7 @@ def stac_search_get(roles=None, **kwargs):
 
         response["links"].append(
             {
-                "href": f"{resolve_stac_url()}/search{f'?{url_encode(args)}' if len(args) > 0 else ''}",
+                "href": f"{resolve_stac_url()}/search{f'?{urlencode(args)}' if len(args) > 0 else ''}",
                 "rel": "next",
             }
         )
@@ -362,7 +362,7 @@ def stac_search_get(roles=None, **kwargs):
 
         response["links"].append(
             {
-                "href": f"{resolve_stac_url()}/search{f'?{url_encode(args)}' if len(args) > 0 else ''}",
+                "href": f"{resolve_stac_url()}/search{f'?{urlencode(args)}' if len(args) > 0 else ''}",
                 "rel": "prev",
             }
         )


### PR DESCRIPTION
- Remove deprecated utils `werkzeug.urls.url_encode` and using python builtin library `urllib.parse.urlencode`
- Upgrade python base image to 3.11